### PR TITLE
Ft api list users #nf 8

### DIFF
--- a/kpi/models/hub_extra_user_detail.py
+++ b/kpi/models/hub_extra_user_detail.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+from django.db import models
+from django.contrib.auth.models import User
+from django.contrib.postgres.fields import JSONField
+
+class HubExtrauserdetail(models.Model):
+    data = JSONField(null=True)
+    # data = models.TextField()
+    user = models.ForeignKey(User, models.DO_NOTHING, unique=True)
+
+    class Meta:
+        managed = False
+        db_table = 'hub_extrauserdetail'


### PR DESCRIPTION
## What does this PR do?
* Enables the list users endpoint
* Adds permissions to the list users endpoint
* Adds extra user details to the list users response

## Description of Task to be completed?
``` [GET] /api/v2/users/ ```
## How should this be manually tested?
After cloning pullng the branch cd into it and start the server with '''pythone manage.py runserver'''
Log into the kpi instance as a super user
Use your browser to test the endpoint above

## What are the relevant pivotal tracker stories?
#NF-8


